### PR TITLE
test: wait for navigation in login spec

### DIFF
--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -9,6 +9,7 @@ test.describe("Login Functionality", () => {
     await page.fill("#user-name", "standard_user")
     await page.fill("#password", "secret_sauce")
     await page.click("#login-button")
+    await page.waitForURL("**/inventory.html")
 
     // Verify redirect to inventory page
     await expect(page).toHaveURL("https://www.saucedemo.com/v1/inventory.html")


### PR DESCRIPTION
## Summary
- ensure login spec waits for redirect

## Testing
- `npx playwright test tests/login.spec.js` *(fails: 403 Forbidden to fetch Playwright from npm)*

------
https://chatgpt.com/codex/tasks/task_e_6853954d95b0832d9ccf45f9d9d60467